### PR TITLE
Iter deep

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -331,7 +331,6 @@ impl BoardState {
     }
 
     fn move_rep_from_masks(&self, start: u64, end: u64) -> MoveRep {
-        // TODO This is probably crashing because it cant handle promotion (which include castling!)
         let moved_piece = self.get_piece_type(start);
         let attacked_piece = self.get_piece_type(end);
         MoveRep {
@@ -620,8 +619,6 @@ impl BoardState {
                     self.set(1 << Tables::H1, Some(PieceType::Rook));
                     self.clear(play.ending_square, Some(PieceType::King));
                     self.clear(1 << Tables::F1, Some(PieceType::Rook));
-                    self.white_queenside_castle_rights = true;
-                    self.white_kingside_castle_rights = true;
                 }
                 e if e == 1 << Tables::C1 => {
                     // White queenside
@@ -629,8 +626,6 @@ impl BoardState {
                     self.set(1 << Tables::A1, Some(PieceType::Rook));
                     self.clear(play.ending_square, Some(PieceType::King));
                     self.clear(1 << Tables::D1, Some(PieceType::Rook));
-                    self.white_queenside_castle_rights = true;
-                    self.white_kingside_castle_rights = true;
                 }
                 e if e == 1 << Tables::G8 => {
                     // Black kingside
@@ -638,8 +633,6 @@ impl BoardState {
                     self.set(1 << Tables::H8, Some(PieceType::Rook));
                     self.clear(play.ending_square, Some(PieceType::King));
                     self.clear(1 << Tables::F8, Some(PieceType::Rook));
-                    self.black_queenside_castle_rights = true;
-                    self.black_kingside_castle_rights = true;
                 }
                 e if e == 1 << Tables::C8 => {
                     // Black queenside
@@ -647,8 +640,6 @@ impl BoardState {
                     self.set(1 << Tables::A8, Some(PieceType::Rook));
                     self.clear(play.ending_square, Some(PieceType::King));
                     self.clear(1 << Tables::D8, Some(PieceType::Rook));
-                    self.black_queenside_castle_rights = true;
-                    self.black_kingside_castle_rights = true;
                 }
                 _ => return,
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ pub mod tables;
 use crate::board::*;
 use crate::comm::*;
 use crate::tables::*;
+use search::id_search;
 use search::negamax;
 use search::perft;
 use std::env;
@@ -16,7 +17,7 @@ use std::time::Instant;
 
 fn main() {
     let mut running = true;
-    let log_file = Path::new("log.txt");
+    let log_file = Path::new("foo.txt");
     let mut comm = Comm::create(log_file).unwrap();
 
     let mut board = BoardState::starting_state();
@@ -100,14 +101,15 @@ fn main() {
                         true => (w_time / 20 + w_inc / 2) as u128,
                         false => (b_time / 20 + b_inc / 2) as u128,
                     };
-                    let best_move = negamax(
+                    let mut node_count = 0;
+                    let best_move = id_search(
                         &mut board,
                         &tables,
-                        5,
+                        7,
                         Some(starting_time),
                         Some(time_to_spend),
-                    )
-                    .unwrap();
+                        &mut node_count,
+                    );
                     comm.engine_out(format!("bestmove {}", best_move.to_string().unwrap()));
                 }
                 "depth" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 
 fn main() {
     let mut running = true;
-    let log_file = Path::new("foo.txt");
+    let log_file = Path::new("log.txt");
     let mut comm = Comm::create(log_file).unwrap();
 
     let mut board = BoardState::starting_state();

--- a/src/search.rs
+++ b/src/search.rs
@@ -539,16 +539,4 @@ mod tests {
         let node_count = perft_search(&mut board, &tables, 5);
         assert_eq!(node_count, 164075551);
     }
-
-    #[test]
-    fn foo() {
-        let mut board = BoardState::starting_state();
-        let mut board = BoardState::state_from_string_fen(
-            "r3k3/8/2nb4/4p3/qp2P3/8/1p6/2BbKBq1 b q - 1 49".to_string(),
-        );
-        let tables = Tables::new();
-        let mut node_count = 0;
-        let _ = id_search(&mut board, &tables, 7, None, None, &mut node_count);
-        assert_eq!(board.occupancy() & 1 << Tables::H8, 0);
-    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -53,25 +53,11 @@ pub fn negamax(
     // If all moves result in draw, none will be picked, so set the bestmove in the event that no moved is picked
     let mut moves = generate(board, tables);
 
-    // Move ordering
-    // TODO I think there should be a better way to do this. Making and unmaking for every move could be costly...
-    // Nonetheless, this improves prefomance significantly
-    // moves.sort_by(|a, b| {
-    //     board.make(&a);
-    //     let a_eval = eval(board, tables);
-    //     board.unmake(&a);
-    //     board.make(&b);
-    //     let b_eval = eval(board, tables);
-    //     board.unmake(&b);
-    //     return a_eval.cmp(&b_eval);
-    // });
-
     let mut best_move = moves[0];
     let mut alpha = isize::MIN;
     let mut beta = isize::MAX;
     let mut node_count = 0;
     for mv in &moves {
-        // println!("\nStarting search for move {}", mv.to_string().unwrap());
         board.make(&mv);
         let score = negamax_child(
             board,
@@ -85,11 +71,6 @@ pub fn negamax(
             &mut node_count,
         )
         .saturating_neg();
-        // println!(
-        //     "Completed search for move {}, with a score of {}",
-        //     mv.to_string().unwrap(),
-        //     score
-        // );
         board.unmake(&mv);
         if score > alpha {
             alpha = score;
@@ -97,12 +78,6 @@ pub fn negamax(
                 return Ok(*mv);
             }
             best_move = *mv;
-            // println!(
-            //     "The move set a new max! The previous max was {}, and the new one is {}",
-            //     max, score
-            // );
-            // max = score;
-            // best_move = *mv;
         }
     }
     return Ok(best_move);
@@ -183,6 +158,37 @@ fn negamax_child(
         }
     }
     return alpha;
+}
+
+/// Preformes a search using iterative deepening
+pub fn id_search(
+    board: &mut BoardState,
+    tables: &Tables,
+    depth: usize,
+    timer: Option<Instant>,
+    duration: Option<u128>,
+    node_count: &mut usize,
+) -> MoveRep {
+    let mut depth_count = 1;
+    let mut mv = generate(board, tables)[0];
+    while !timer_check(timer, duration) && depth_count != depth {
+        mv = negamax(board, tables, depth_count, timer, duration).unwrap();
+        depth_count += 1;
+    }
+    mv
+}
+
+pub fn timer_check(timer: Option<Instant>, duration: Option<u128>) -> bool {
+    match (timer, duration) {
+        (Some(t), Some(d)) => {
+            if t.elapsed().as_millis() > d {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        _ => return false,
+    }
 }
 
 #[cfg(test)]
@@ -532,5 +538,17 @@ mod tests {
         let tables = Tables::new();
         let node_count = perft_search(&mut board, &tables, 5);
         assert_eq!(node_count, 164075551);
+    }
+
+    #[test]
+    fn foo() {
+        let mut board = BoardState::starting_state();
+        let mut board = BoardState::state_from_string_fen(
+            "r3k3/8/2nb4/4p3/qp2P3/8/1p6/2BbKBq1 b q - 1 49".to_string(),
+        );
+        let tables = Tables::new();
+        let mut node_count = 0;
+        let _ = id_search(&mut board, &tables, 7, None, None, &mut node_count);
+        assert_eq!(board.occupancy() & 1 << Tables::H8, 0);
     }
 }


### PR DESCRIPTION
Basic Iterative Deepening
fastchess results:
Results of nuttchess vs nutchess-main (1, NULL, NULL, 8moves_v3.pgn):
Elo: 174.02 +/- 44.89, nElo: 201.35 +/- 43.77
LOS: 100.00 %, DrawRatio: 30.58 %, PairsRatio: 8.33
Games: 242, Wins: 159, Losses: 47, Draws: 36, Points: 177.0 (73.14 %)
Ptnml(0-2): [6, 3, 37, 23, 52], WL/DD Ratio: 6.40
LLR: 2.95 (-2.94, 2.94) [0.00, 10.00]