### PR TITLE
Search: Implemented quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -125,7 +125,9 @@ fn negamax_child(
     }
     if depth == 0 {
         *node_count += 1;
-        return eval(board, tables, moves.len(), last_number_of_moves);
+        // TODO Investigate delta pruning. The fact that depth limits greater than 2 dont really improve preformance suggests
+        // that this is not really a great approach
+        return quiescence(board, tables, alpha, beta, 2, timer, duration, moves.len());
     }
     for mv in &moves {
         match (timer, duration) {
@@ -210,6 +212,69 @@ pub fn id_search(
     }
 
     current_best
+}
+
+/// Preform the quiescence search
+fn quiescence(
+    board: &mut BoardState,
+    tables: &Tables,
+    mut alpha: isize,
+    mut beta: isize,
+    depth: usize,
+    timer: Option<Instant>,
+    duration: Option<u128>,
+    last_number_moves: usize,
+) -> isize {
+    let moves = generate(board, tables);
+    let number_moves = moves.len();
+    let initial_eval = eval(board, tables, number_moves, last_number_moves);
+    // TODO Investigate using delta pruning instead of an arbitrary depth limit
+    if depth == 0 {
+        return initial_eval;
+    }
+    let mut best_value = initial_eval;
+
+    if initial_eval >= beta {
+        return initial_eval;
+    }
+    if alpha < initial_eval {
+        alpha = initial_eval;
+    }
+
+    for mv in &moves {
+        if timer_check(timer, duration) {
+            break;
+        }
+        // TODO Make a diffrent move generation function which only produces captures
+        if mv.ending_square & board.occupancy() == 0 {
+            // Skip non captures
+            continue;
+        }
+        board.make(&mv);
+        let score = quiescence(
+            board,
+            tables,
+            beta.saturating_neg(),
+            alpha.saturating_neg(),
+            depth - 1,
+            timer,
+            duration,
+            number_moves,
+        )
+        .saturating_neg();
+        board.unmake(&mv);
+        if score >= beta {
+            return score;
+        }
+        if score > best_value {
+            best_value = score;
+        }
+        if score > alpha {
+            alpha = score;
+        }
+    }
+
+    best_value
 }
 
 pub fn timer_check(timer: Option<Instant>, duration: Option<u128>) -> bool {


### PR DESCRIPTION
Implemented Quiescence search
Results of quiescence vs main (1, NULL, NULL, 8moves_v3.pgn):
Elo: 101.09 +/- 30.54, nElo: 134.07 +/- 38.19
LOS: 100.00 %, DrawRatio: 28.30 %, PairsRatio: 3.38
Games: 318, Wins: 145, Losses: 55, Draws: 118, Points: 204.0 (64.15 %)
Ptnml(0-2): [4, 22, 45, 56, 32], WL/DD Ratio: 1.25
LLR: 2.95 (-2.94, 2.94) [0.00, 10.00]

In the future, it would be best to use 'delta pruning' instead of a depth cap on this, since it does not improve performance past a depth of 2. 