### PR TITLE
Search: Removed the hacky 'move ordering', and reformated id_search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -173,45 +173,20 @@ pub fn id_search(
     duration: Option<u128>,
     node_count: &mut usize,
 ) -> MoveRep {
-    // Create a vector of tuples containing the possible moves, and the scores of those moves
-    let mut moves = generate(board, tables);
-    let mut scores = vec![0; moves.len()];
-    let mut move_scores: Vec<(MoveRep, isize)> = zip(moves, scores).collect();
-    let move_length = move_scores.len();
-    let mut current_best = move_scores[0].0;
     let mut current_depth = 1;
+    let mut best_move = negamax(board, tables, 1, None, None);
 
-    while !timer_check(timer, duration) {
-        // First, generate the scores
-        let mut alpha = isize::MIN;
-        let mut beta = isize::MAX;
-
-        for ms in &mut move_scores {
-            if timer_check(timer, duration) {
-                return current_best;
-            }
-            board.make(&ms.0);
-            ms.1 = negamax_child(
-                board,
-                tables,
-                alpha,
-                beta,
-                move_length,
-                current_depth,
-                timer,
-                duration,
-                node_count,
-            );
-            board.unmake(&ms.0);
-        }
-
-        // Now sort the move scores for the next iteration
-        move_scores.sort_by(|a, b| a.1.cmp(&b.1));
-        current_best = move_scores[0].0;
+    loop {
         current_depth += 1;
+        let possible_best = negamax(board, tables, current_depth, timer, duration);
+        if !timer_check(timer, duration) {
+            best_move = possible_best;
+        } else {
+            break;
+        }
     }
 
-    current_best
+    best_move.unwrap()
 }
 
 /// Preform the quiescence search


### PR DESCRIPTION
Results of move_ord vs main (1+0.08, NULL, NULL, 8moves_v3.pgn):
Elo: 153.85 +/- 37.91, nElo: 204.70 +/- 44.14
LOS: 100.00 %, DrawRatio: 26.89 %, PairsRatio: 6.25
Games: 238, Wins: 123, Losses: 24, Draws: 91, Points: 168.5 (70.80 %)
Ptnml(0-2): [1, 11, 32, 38, 37], WL/DD Ratio: 0.52
LLR: 2.96 (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------