### PR TITLE
Search, Eval, & Main: Started move ordering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,8 +131,15 @@ fn main() {
                     match depth {
                         Some(d) => {
                             if let Ok(depth_number) = d.parse::<u64>() {
-                                let best_move =
-                                    negamax(&mut board, &tables, depth_number as usize, None, None);
+                                let mut test_counter = 0;
+                                let best_move = negamax(
+                                    &mut board,
+                                    &tables,
+                                    depth_number as usize,
+                                    None,
+                                    None,
+                                    &mut test_counter,
+                                );
                                 comm.engine_out(format!(
                                     "bestmove {}",
                                     best_move.unwrap().to_string().unwrap()


### PR DESCRIPTION
Results of move_ord vs main (1+0.08, NULL, NULL, 8moves_v3.pgn):
Elo: 152.93 +/- 29.43, nElo: 264.48 +/- 44.71
LOS: 100.00 %, DrawRatio: 29.31 %, PairsRatio: 19.50
Games: 232, Wins: 105, Losses: 9, Draws: 118, Points: 164.0 (70.69 %)
Ptnml(0-2): [0, 4, 34, 56, 22], WL/DD Ratio: 0.17
LLR: 2.95 (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------

I strongly suspect that the move ordering is not improving performance nearly as much as it should. Maybe you can only get so far without using PV or other techniques? In any case, the changes have improved performance, so I will add them anyway. 